### PR TITLE
MLT-638

### DIFF
--- a/scripts/periodic_scripts.js
+++ b/scripts/periodic_scripts.js
@@ -149,11 +149,12 @@ const updateFrequency = async (db) => {
                   params: {
                     q: `reporting_org_ref:${signatory.IATIOrgRef} AND
                         transaction_date_iso_date:[${freqItem[1]}T00:00:00Z TO ${freqItem[1]}T23:59:59Z]
-                        AND (humanitarian:1 OR sector_vocabulary:1 OR (-sector_vocabulary:*
-                        AND (sector_code:[70000 TO 79999] OR sector_code:[93010 TO 93018]))
-                        OR transaction_humanitarian:1 OR transaction_sector_vocabulary:1
-                        OR (-transaction_sector_vocabulary:* AND (transaction_sector_code:[70000 TO 79999]
-                        OR transaction_sector_code:[93010 TO 93018])))`,
+                        AND (humanitarian:1 OR transaction_humanitarian:1 OR 
+                        ((sector_vocabulary:1 OR -sector_vocabulary:*) AND 
+                        (sector_code:[70000 TO 79999] OR sector_code:[93010 TO 93018])) OR 
+                        ((transaction_sector_vocabulary:1 OR -transaction_sector_vocabulary:*) AND 
+                        (transaction_sector_code:[70000 TO 79999] OR
+                         transaction_sector_code:[93010 TO 93018])))`,
                     rows: "0"
                   }
                 });


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/MLT-638

Correct the sector condition for hum query. Do this through out the portal wherever we use the humanitarian condition as mentioned here - https://basecamp.com/1938785/projects/16465375/messages/88239897#comment_729712269 . 
Currently the way the query condition works is - 
sector/@vocab = 1 OR (@vocab not present and 
(sector/@code > 69999 and < 80000
OR sector/@code 93010 to 93018)) 
BUT it should be like this - 
(sector/@vocab = 1 OR @vocab not present) and 
(sector/@code > 69999 and < 80000
OR sector/@code 93010 to 93018) 